### PR TITLE
feat: change location sharing to use device location

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "expo": "^53.0.12",
         "expo-constants": "~17.1.4",
         "expo-linking": "~7.1.4",
+        "expo-location": "~18.1.5",
         "expo-router": "~5.1.0",
         "expo-status-bar": "~2.2.3",
         "expo-system-ui": "~5.0.6",
@@ -964,6 +965,8 @@
     "expo-keep-awake": ["expo-keep-awake@14.1.4", "", { "peerDependencies": { "expo": "*", "react": "*" } }, "sha512-wU9qOnosy4+U4z/o4h8W9PjPvcFMfZXrlUoKTMBW7F4pLqhkkP/5G4EviPZixv4XWFMjn1ExQ5rV6BX8GwJsWA=="],
 
     "expo-linking": ["expo-linking@7.1.5", "", { "dependencies": { "expo-constants": "~17.1.6", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-8g20zOpROW78bF+bLI4a3ZWj4ntLgM0rCewKycPL0jk9WGvBrBtFtwwADJgOiV1EurNp3lcquerXGlWS+SOQyA=="],
+
+    "expo-location": ["expo-location@18.1.5", "", { "peerDependencies": { "expo": "*" } }, "sha512-/ugxS4Ort9DbKD0Do6xn4TjeHaA/by5vv0p0PrY5Zbcez1S0AfrQn/4JG/8PLT2imngMwZU9TDKrgxqJQ4RuPQ=="],
 
     "expo-modules-autolinking": ["expo-modules-autolinking@2.1.12", "", { "dependencies": { "@expo/spawn-async": "^1.7.2", "chalk": "^4.1.0", "commander": "^7.2.0", "find-up": "^5.0.0", "glob": "^10.4.2", "require-from-string": "^2.0.2", "resolve-from": "^5.0.0" }, "bin": { "expo-modules-autolinking": "bin/expo-modules-autolinking.js" } }, "sha512-rW5YSW66pUx1nLqn7TO0eWRnP4LDvySW1Tom0wjexk3Tx/upg9LYE5tva7p5AX/cdFfiZcEqPcOxP4RyT++Xlg=="],
 

--- a/components/LocationSelector.tsx
+++ b/components/LocationSelector.tsx
@@ -1,14 +1,65 @@
-import { View, Text, Pressable } from 'react-native';
-import { MapPinIcon } from 'react-native-heroicons/solid';
+import { View, Text, Pressable, Alert } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+import * as Location from 'expo-location';
+import { create } from 'zustand';
+
+// Zustand store for location
+type LocationState = {
+  locationName: string;
+  setLocationName: (name: string) => void;
+};
+
+export const useLocationStore = create<LocationState>((set) => ({
+  locationName: 'Kolkata',
+  setLocationName: (name) => set({ locationName: name }),
+}));
+
+// Helper to reverse geocode coordinates to a city name
+async function getCityNameFromCoords(latitude: number, longitude: number): Promise<string> {
+  try {
+    const geocode = await Location.reverseGeocodeAsync({ latitude, longitude });
+    if (geocode && geocode.length > 0) {
+      // Prefer city, fallback to region or country
+      return geocode[0].city || geocode[0].region || geocode[0].country || 'Unknown';
+    }
+    return 'Unknown';
+  } catch {
+    return 'Unknown';
+  }
+}
 
 export default function LocationSelector() {
+  const locationName = useLocationStore((state) => state.locationName);
+  const setLocationName = useLocationStore((state) => state.setLocationName);
+
+  // Optionally, on mount, try to get location permission and update location
+  // useEffect(() => {
+  //   handleUpdateLocation();
+  // }, []);
+
+  const handleUpdateLocation = async () => {
+    let { status } = await Location.requestForegroundPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Permission denied', 'Location permission is required to update your location.');
+      return;
+    }
+
+    try {
+      const loc = await Location.getCurrentPositionAsync({});
+      const city = await getCityNameFromCoords(loc.coords.latitude, loc.coords.longitude);
+      setLocationName(city);
+    } catch (e) {
+      Alert.alert('Error', 'Could not fetch location.');
+    }
+  };
+
   return (
     <View className="mx-4 mt-4 flex-row items-center justify-between rounded-xl border border-gray-200 bg-white p-3">
       <View className="flex-row items-center space-x-1">
-        <MapPinIcon color="#F97316" size={20} />
-        <Text className="text-base font-medium">Kolkata</Text>
+        <MaterialIcons name="location-on" color="#F97316" size={20} />
+        <Text className="text-base font-medium">{locationName}</Text>
       </View>
-      <Pressable className="rounded-lg bg-gray-100 px-3 py-1">
+      <Pressable className="rounded-lg bg-gray-100 px-3 py-1" onPress={handleUpdateLocation}>
         <Text className="text-sm font-semibold">Update</Text>
       </Pressable>
     </View>

--- a/components/QuickActionsGrid.tsx
+++ b/components/QuickActionsGrid.tsx
@@ -1,20 +1,37 @@
 import { View, Text, Pressable } from 'react-native';
-import {
-  ChatBubbleLeftIcon,
-  ExclamationTriangleIcon,
-  ClipboardIcon,
-  UserIcon,
-  MapPinIcon,
-  MapIcon,
-} from 'react-native-heroicons/solid';
+import { MaterialIcons, MaterialCommunityIcons } from '@expo/vector-icons';
 
 const actions = [
-  { icon: ChatBubbleLeftIcon, label: 'Send Message' },
-  { icon: ExclamationTriangleIcon, label: 'Broadcast SOS', color: 'text-red-500' },
-  { icon: ClipboardIcon, label: 'Report Resource Need' },
-  { icon: UserIcon, label: 'Share My Status' },
-  { icon: MapPinIcon, label: 'Nearby Alerts' },
-  { icon: MapIcon, label: 'Community Map' },
+  {
+    icon: (props: any) => <MaterialIcons name="chat" {...props} />,
+    label: 'Send Message',
+    color: 'text-blue-500',
+  },
+  {
+    icon: (props: any) => <MaterialIcons name="sos" {...props} />,
+    label: 'Broadcast SOS',
+    color: 'text-red-500',
+  },
+  {
+    icon: (props: any) => <MaterialIcons name="assignment" {...props} />,
+    label: 'Report Resource Need',
+    color: 'text-blue-500',
+  },
+  {
+    icon: (props: any) => <MaterialIcons name="person" {...props} />,
+    label: 'Share My Status',
+    color: 'text-blue-500',
+  },
+  {
+    icon: (props: any) => <MaterialIcons name="location-on" {...props} />,
+    label: 'Nearby Alerts',
+    color: 'text-blue-500',
+  },
+  {
+    icon: (props: any) => <MaterialCommunityIcons name="map" {...props} />,
+    label: 'Community Map',
+    color: 'text-blue-500',
+  },
 ];
 
 export default function QuickActionsGrid() {
@@ -24,7 +41,10 @@ export default function QuickActionsGrid() {
         <Pressable
           key={i}
           className="m-1 aspect-square w-[30%] items-center justify-center rounded-xl bg-white shadow-md">
-          <action.icon size={28} className={`${action.color ?? 'text-blue-500'}`} />
+          {action.icon({
+            size: 28,
+            color: action.color === 'text-red-500' ? '#ef4444' : '#3b82f6',
+          })}
           <Text className="mt-1 text-center text-xs">{action.label}</Text>
         </Pressable>
       ))}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "expo": "^53.0.12",
     "expo-constants": "~17.1.4",
     "expo-linking": "~7.1.4",
+    "expo-location": "~18.1.5",
     "expo-router": "~5.1.0",
     "expo-status-bar": "~2.2.3",
     "expo-system-ui": "~5.0.6",


### PR DESCRIPTION
This PR implements a new feature for LocationSelector:

- Adds native on-device location functionality for update button.
- Minor UI changes (icons from hero to material)

Tested on: Android, confirmed to be working